### PR TITLE
Re-export DType to the public interface ...

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -9,8 +9,20 @@ use polars::{datatypes::DataType::Float32, prelude::*};
 
 use crate::{Error, Result};
 
+// a way of implementing sealed traits until they
+// come to rust lang. more details at:
+// https://internals.rust-lang.org/t/sealed-traits/16797
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for f32 {}
+    impl Sealed for f64 {}
+}
 /// LightGBM dtype
-pub trait DType {
+///
+/// This trait is sealed as it is not intended
+/// to be implemented out of this crate
+pub trait DType: private::Sealed {
     fn get_c_api_dtype() -> i32;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ mod dataset;
 mod error;
 
 pub use booster::{Booster, ImportanceType};
-pub use dataset::Dataset;
+pub use dataset::{DType, Dataset};
 pub use error::{Error, Result};
 
 /// Get index of the element in a slice with the maximum value


### PR DESCRIPTION
... as it could be used to restrict other types

like:

```
<I as ArrowPrimitiveType>::Native: DType,
```

I see no alternatives to exposing this trait.