### PR TITLE
[docs] fix OpenMP and CUDA descriptions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Look in the [`./examples/`](https://github.com/Mottl/lightgbm3-rs/blob/main/exam
 ## Features
 **`lightgbm3`** supports the following features:
 - `polars` for [polars](https://github.com/pola-rs/polars) support
-- `openmp` for [MPI](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-mpi-version) support 
+- `openmp` for [multi-processing](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-threadless-version-not-recommended) support 
 - `gpu` for [GPU](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-gpu-version) support
-- `cuda` for experimental [CUDA](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-cuda-version) support
+- `cuda` for [CUDA](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-cuda-version) support
 
 ## Benchmarks
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! **`lightgbm3`** supports the following features:
 //! - `polars` for [polars](https://github.com/pola-rs/polars) support
-//! - `openmp` for [MPI](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-mpi-version) support
+//! - `openmp` for [multi-processing](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-threadless-version-not-recommended) support
 //! - `gpu` for [GPU](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-gpu-version) support
 //! - `cuda` for experimental [CUDA](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-cuda-version) support
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! - `polars` for [polars](https://github.com/pola-rs/polars) support
 //! - `openmp` for [multi-processing](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-threadless-version-not-recommended) support
 //! - `gpu` for [GPU](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-gpu-version) support
-//! - `cuda` for experimental [CUDA](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-cuda-version) support
+//! - `cuda` for [CUDA](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-cuda-version) support
 //!
 //! # Examples
 //! ### Training:


### PR DESCRIPTION
- openmp means [`OpenMP`](https://github.com/microsoft/LightGBM/blob/602528315c6d5e4ae1e8f5de106cf56cf5869b16/CMakeLists.txt#L2), not [`OpenMPI`](https://github.com/microsoft/LightGBM/blob/602528315c6d5e4ae1e8f5de106cf56cf5869b16/CMakeLists.txt#L1)
- [`CUDA` is no longer experimental](https://github.com/microsoft/LightGBM/pull/6371)